### PR TITLE
Fix Lua keywords

### DIFF
--- a/src/lexers/init.lua
+++ b/src/lexers/init.lua
@@ -35,9 +35,8 @@ local function compile_keywords(context, keywords)
     pattern = pattern and (pattern + p) or p
   end
   local B = context.word_boundary or B
-  local BB = lpeg.B(B, 1) + SOS -- starting boundary
   local AB = B + EOS -- ending boundary
-  return BB * pattern * AB
+  return pattern * AB
 end
 
 -- Closure to define token type given name and LPeg pattern.

--- a/test/lexers.lua
+++ b/test/lexers.lua
@@ -235,6 +235,67 @@ check_tokens(lxsh.lexers.lua.gmatch(keywords), {
   { 'keyword', 'while' },
 })
 
+-- Keywords II. {{{2
+local code_with_keywords = [[if true and not false or nil then
+  repeat
+    break
+  until true
+elseif 1 then
+  local a = 1
+else
+  for k, v in pairs(_G) do
+    local f = function()  end
+  end
+end
+
+while true do end
+
+return 1]]
+
+check_tokens(lxsh.lexers.lua.gmatch(code_with_keywords), {
+  { 'keyword', 'if' }, { 'whitespace', ' ' },
+  { 'constant', 'true' }, { 'whitespace', ' ' },
+  { 'operator', 'and' }, { 'whitespace', ' ' },
+  { 'operator', 'not' }, { 'whitespace', ' ' },
+  { 'constant', 'false' }, { 'whitespace', ' ' },
+  { 'operator', 'or' }, { 'whitespace', ' ' },
+  { 'constant', 'nil' }, { 'whitespace', ' ' },
+  { 'keyword', 'then' }, { 'whitespace', '\n  ' },
+  { 'keyword', 'repeat' }, { 'whitespace', '\n    ' },
+  { 'keyword', 'break' }, { 'whitespace', '\n  ' },
+  { 'keyword', 'until' }, { 'whitespace', ' ' },
+  { 'constant', 'true' }, { 'whitespace', '\n' },
+  { 'keyword', 'elseif' }, { 'whitespace', ' ' },
+  { 'number', '1' }, { 'whitespace', ' ' },
+  { 'keyword', 'then' }, { 'whitespace', '\n  ' },
+  { 'keyword', 'local' }, { 'whitespace', ' ' },
+  { 'identifier', 'a' }, { 'whitespace', ' ' },
+  { 'operator', '=' }, { 'whitespace', ' ' },
+  { 'number', '1' }, { 'whitespace', '\n' },
+  { 'keyword', 'else' }, { 'whitespace', '\n  ' },
+  { 'keyword', 'for' }, { 'whitespace', ' ' },
+  { 'identifier', 'k' }, { 'operator', ',' }, { 'whitespace', ' ' },
+  { 'identifier', 'v' }, { 'whitespace', ' ' },
+  { 'keyword', 'in' }, { 'whitespace', ' ' },
+  { 'identifier', 'pairs' }, { 'operator', '(' }, { 'identifier', '_G' },
+    { 'operator', ')' }, { 'whitespace', ' ' },
+  { 'keyword', 'do' }, { 'whitespace', '\n    ' },
+  { 'keyword', 'local' }, { 'whitespace', ' ' },
+  { 'identifier', 'f' }, { 'whitespace', ' ' },
+  { 'operator', '=' }, { 'whitespace', ' ' },
+  { 'keyword', 'function' }, { 'operator', '(' }, { 'operator', ')' },
+    { 'whitespace', '  ' },
+  { 'keyword', 'end' }, { 'whitespace', '\n  ' },
+  { 'keyword', 'end' }, { 'whitespace', '\n' },
+  { 'keyword', 'end' }, { 'whitespace', '\n\n' },
+  { 'keyword', 'while' }, { 'whitespace', ' ' },
+  { 'constant', 'true' }, { 'whitespace', ' ' },
+  { 'keyword', 'do' }, { 'whitespace', ' ' },
+  { 'keyword', 'end' }, { 'whitespace', '\n\n' },
+  { 'keyword', 'return' }, { 'whitespace', ' ' },
+  { 'number', '1' },
+})
+
 -- Identifiers. {{{2
 check_tokens(lxsh.lexers.lua.gmatch('io.write'), {
   { 'identifier', 'io' },


### PR DESCRIPTION
**Problem:** Lua keywords don't have recognized properly. They are treated as identifiers.
**Example:**
Source to parse:
```Lua
if true and not false or nil then
  repeat
    break
  until true
elseif 1 then
  local a = 1
else
  for k, v in pairs(_G) do
    local f = function()  end
  end
end

while true do end

return 1
```
Parsing:
```Lua
for kind, text in lxsh.lexers.lua.gmatch(source) do
  if kind ~= 'whitespace' then
    print(kind, text)
  end
end
```
Result:
```
keyword if
constant true
operator and
operator not
constant false
operator or
constant nil
identifier then
identifier repeat
identifier break
identifier until
constant true
identifier elseif
number 1
identifier then
identifier local
identifier a
operator =
number 1
identifier else
identifier for
identifier k
operator ,
identifier v
identifier in
identifier pairs
operator (
identifier _G
operator )
identifier do
identifier local
identifier f
operator =
identifier function
operator (
operator )
identifier end
identifier end
identifier end
identifier while
constant true
identifier do
identifier end
identifier return
number 1
```

Only the first `if` is recognized properly.

**Solution:** fix the keyword pattern.
